### PR TITLE
Remove childContext

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,7 +1,6 @@
 import * as React from "react";
 import Document, { Head, Main, NextScript } from "next/document";
 import flush from "styled-jsx/server";
-import PropTypes from "prop-types";
 
 class MyDocument extends Document {
   static getInitialProps(context) {
@@ -9,10 +8,6 @@ class MyDocument extends Document {
     const { html, head, errorHtml, chunks } = renderPage();
     const styles = flush();
     return { html, head, errorHtml, chunks, styles };
-  }
-
-  getChildContext() {
-    return { _documentProps: this.props };
   }
 
   render() {
@@ -27,9 +22,5 @@ class MyDocument extends Document {
     );
   }
 }
-
-MyDocument.childContextTypes = {
-  _documentProps: PropTypes.any
-};
 
 export default MyDocument;


### PR DESCRIPTION
This causes issues between upgrades and is not needed as Document is extended, it’s Next.js internals being overwritten basically.